### PR TITLE
Added Dockerfile and added Docker build steps to Makefile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM ubuntu
+
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive \
+    apt-get install -y python2.7 make vowpal-wabbit r-base r-base-core r-cran-ggplot2 git && \
+    ln -s /usr/bin/python2.7 /usr/local/bin/python2
+
+CMD make

--- a/Makefile
+++ b/Makefile
@@ -161,6 +161,15 @@ conv: $(TRAINFILE)
 clean:
 	/bin/rm -f $(MODELFILE) $(ITEMFILE) $(RANGEFILE) *.cache* *.tmp*
 
+db docker-build:
+	docker build -t score .
+
+ds docker-score: docker-build
+	docker run -v $(CURDIR):$(CURDIR) -w $(CURDIR) score make
+
+dsc docker-score-chart: docker-build
+	docker run -v $(CURDIR):$(CURDIR) -w $(CURDIR) score make sc
+
 # -- more friendly error if original data doesn't exist
 $(MASTERDATA):
 	@echo "=== Sorry: you must provide your data in '$(MASTERDATA)'"
@@ -176,4 +185,3 @@ gh:
 	git merge master && \
 	git push && \
 	git checkout master
-


### PR DESCRIPTION
Hi Ariel,

I have created a Dockerfile which installs all the dependencies required to run this script and also updated the Makefile to add some make docker commands.

I renamed the file `ariel.csv` to `root.csv` due to it looking for the username :

```
mv ariel.csv root.csv
```

Then I run the following make command :

```
make docker-score-chart
```

or the abbreviated command is :

```
make dsc
```

It will then build the docker container if it doesn't exist and then generate the `scores.txt` and `root.scores.png` files.

I was hoping to be able to use your repository to help with doing similar machine-learning but with Irritable Bowel Syndrome (IBS) Symptoms.

Instead of adding in weight we instead add in a digestive symptom score which is calculated by an app called [Cara](https://cara-app.com/)  :

> The symptom score is calculated on the basis of the symptoms tracked with Cara. The value can be between 0 and 100. The higher the symptom score, the more severe are the digestive problems in the region.

There was a discussion earlier today on Reddit about using Machine Learning to troubleshoot IBS symptoms :
https://www.reddit.com/r/ibs/comments/9f1w46/im_working_on_a_startup_to_find_individual/

and it reminded me of your Weight Loss machine learning repository I looked at a while ago, any way let me know what you think!

