### PR TITLE
Fix vw-varinfo for Python3

### DIFF
--- a/vw-varinfo2
+++ b/vw-varinfo2
@@ -212,13 +212,9 @@ def vw_audit(vw_cmd, our_input=None):
             stdin=subprocess.PIPE,
             bufsize=1048576
         )
-        # python3 desn't like this:
-        #   TypeError: a bytes-like object is required, not 'str'
-        vw_proc.stdin.write(our_input)
-        # But if I try this, python3 doesn't work at all...
-        #   vw_proc.stdin.write(bytes(our_input, 'utf-8'))
-        # and OTOH python2 doesn't like the 2 args to bytes
-        # vw_proc.stdin.write(our_input.encode('utf-8'))
+        # python3 expects a bytes-like object
+        # Hence encoding the string our_input
+        vw_proc.stdin.write(our_input.encode())
         vw_proc.stdin.close()
     else:
         # By default, vw reads from a training-set
@@ -234,7 +230,9 @@ def vw_audit(vw_cmd, our_input=None):
     example_no = 0
 
     while True:
-        vw_line = vw_proc.stdout.readline()
+        # Since encoded string was written
+        # therefore it needs to be decoded
+        vw_line = vw_proc.stdout.readline().decode()
         if not vw_line:
             # End of input
             vw_proc.stdout.close()


### PR DESCRIPTION
Fixes the following problem of vw-varinfo2 with Python3  
```python
== FATAL: a bytes-like object is required, not 'str'
Traceback (most recent call last):
  File "vw-varinfo2", line 467, in main
    pass2()
  File "vw-varinfo2", line 443, in pass2
    run_vw(vw_cmd, all_features)
  File "vw-varinfo2", line 273, in run_vw
    for line in vw_audit(vw_cmd, our_input):
  File "vw-varinfo2", line 217, in vw_audit
    vw_proc.stdin.write(our_input)
TypeError: a bytes-like object is required, not 'str'
```
After encoding the string, it needs to be decoded.